### PR TITLE
example of building configs based on RoboRIO serial number

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -9,15 +9,6 @@ import frc.com.swervedrivespecialties.swervelib.MechanicalConfiguration;
 import frc.com.swervedrivespecialties.swervelib.SdsModuleConfigurations;
 
 public class Constants {
-    //for a 25x25 dirvetrain
-    // public static final double DRIVETRAIN_TRACKWIDTH_METERS = 0.508;
-    // public static final double DRIVETRAIN_WHEELBASE_METERS = 0.508;
-
-    //for a 30x30 drivetrain
-    public static final double DRIVETRAIN_TRACKWIDTH_METERS = 0.508 + 0.127;
-    public static final double DRIVETRAIN_WHEELBASE_METERS = 0.508 + 0.127;
-
-    public static final int DRIVETRAIN_PIGEON_ID = 6;
 
     // hulk
     // public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(118.6253437499); //116.806640625

--- a/src/main/java/frc/robot/config/GatorConfig.java
+++ b/src/main/java/frc/robot/config/GatorConfig.java
@@ -1,0 +1,162 @@
+package frc.robot.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Named GatorConfig because RobotConfig was already taken by wpilibj.
+ * The intention here is  to replace Constants.java with this class.
+ * Instead of having a bunch of commented out constants for different chassis,
+ * we can just have a different config for each chassis, and load the right
+ * one based on the RoboRIOserial number.
+ */
+public class GatorConfig {
+
+    // these are still actual constants.
+    // they're static so they can be reused in specific configs,
+    // but they're private so that other places in the code still
+    // go through a config object.
+
+    //for a 25x25 dirvetrain
+    private static final double DRIVETRAIN_TRACKWIDTH_METERS_25X25 = 0.508;
+    private static final double DRIVETRAIN_WHEELBASE_METERS_25X25 = 0.508;
+
+    //for a 30x30 drivetrain
+    private static final double DRIVETRAIN_TRACKWIDTH_METERS_30X30 = 0.508 + 0.127;
+    private static final double DRIVETRAIN_WHEELBASE_METERS_30X30 = 0.508 + 0.127;
+
+    // Pigeon ID never changes
+    private static final int DRIVETRAIN_PIGEON_ID = 6;
+
+    // these are member variables for the actual config.
+    private double driveTrainTrackWidthMeters;
+    private double driveTrainWheelBaseMeters;
+    private int driveTrainPigeonId;
+    private double driveTrainFrontLeftModuleSteerOffset;
+    private double driveTrainFrontRightModuleSteerOffset;
+    private double driveTrainBackLeftModuleSteerOffset;
+    private double driveTrainBackRightModuleSteerOffset;
+    
+    // your average run of the mill constructor
+    public GatorConfig(
+            double driveTrainTrackWidthMeters,
+            double driveTrainWheelBaseMeters,
+            int driveTrainPigeonId,
+            double driveTrainFrontLeftModuleSteerOffset,
+            double driveTrainFrontRightModuleSteerOffset,
+            double driveTrainBackLeftModuleSteerOffset,
+            double driveTrainBackRightModuleSteerOffset) {
+        this.driveTrainTrackWidthMeters = driveTrainTrackWidthMeters;
+        this.driveTrainWheelBaseMeters = driveTrainWheelBaseMeters;
+        this.driveTrainPigeonId = driveTrainPigeonId;
+        this.driveTrainFrontLeftModuleSteerOffset = driveTrainFrontLeftModuleSteerOffset;
+        this.driveTrainFrontRightModuleSteerOffset = driveTrainFrontRightModuleSteerOffset;
+        this.driveTrainBackLeftModuleSteerOffset = driveTrainBackLeftModuleSteerOffset;
+        this.driveTrainBackRightModuleSteerOffset = driveTrainBackRightModuleSteerOffset;
+    }
+
+    public double getDriveTrainTrackWidthMeters() {
+        return driveTrainTrackWidthMeters;
+    }
+
+    public double getDriveTrainWheelBaseMeters() {
+        return driveTrainWheelBaseMeters;
+    }
+
+    public int getDriveTrainPigeonId() {
+        return driveTrainPigeonId;
+    }
+
+    public double getDriveTrainFrontLeftModuleSteerOffset() {
+        return driveTrainFrontLeftModuleSteerOffset;
+    }
+
+    public double getDriveTrainFrontRightModuleSteerOffset() {
+        return driveTrainFrontRightModuleSteerOffset;
+    }
+
+    public double getDriveTrainBackLeftModuleSteerOffset() {
+        return driveTrainBackLeftModuleSteerOffset;
+    }
+
+    public double getDriveTrainBackRightModuleSteerOffset() {
+        return driveTrainBackRightModuleSteerOffset;
+    }
+
+    // this is a static method that returns a new config based on the RoboRIO serial number.
+    // you can call this in robot container, drivetrainsubsystem, whatever.
+    public static GatorConfig getConfig() {
+        String serialNum;
+        // try to read the serial number from the RoboRIO
+        try {
+            serialNum = new String(Files.readAllBytes(Paths.get("/sys/firmware/serial_number"))).trim();
+        } catch (IOException e) {
+            System.err.println("Failed to read RoboRIO serial number. Defaulting to practice bot config.");
+            return getCompBotConfig(); // Default to comp bot for now
+        }
+
+        // based on the serial number, return the correct config.
+        switch (serialNum) {
+            case "031b1d4b": // Comp Bot
+                return getCompBotConfig();
+            case "nemo_serial": // Replace with actual serial
+                return getNemoConfig();
+            case "hulk_serial": // Replace with actual serial
+                return getHulkConfig();
+            case "dory_serial": // Replace with actual serial
+                return getDoryConfig();
+            default:
+                System.err.println("Unknown robot serial number: " + serialNum + ". Defaulting to comp bot config.");
+                return getCompBotConfig();
+        }
+    }
+
+    private static GatorConfig getCompBotConfig() {
+        return new GatorConfig(
+            DRIVETRAIN_TRACKWIDTH_METERS_25X25,
+            DRIVETRAIN_WHEELBASE_METERS_25X25,
+            DRIVETRAIN_PIGEON_ID,
+            -268.0664, // Direct from Constants.java
+            -231.3281, // Direct from Constants.java
+            -169.3652, // Direct from Constants.java
+            -52.1191   // Direct from Constants.java
+        );
+    }
+
+    private static GatorConfig getNemoConfig() {
+        return new GatorConfig(
+            DRIVETRAIN_TRACKWIDTH_METERS_30X30,
+            DRIVETRAIN_WHEELBASE_METERS_30X30,
+            DRIVETRAIN_PIGEON_ID,
+            336.094,    // These values were in degrees in Constants
+            225.176,
+            243.369,
+            204.256
+        );
+    }
+
+    private static GatorConfig getHulkConfig() {
+        return new GatorConfig(
+            DRIVETRAIN_TRACKWIDTH_METERS_25X25,
+            DRIVETRAIN_WHEELBASE_METERS_25X25,
+            DRIVETRAIN_PIGEON_ID,
+            118.6253437499,
+            283.7109375,
+            124.0988159179,
+            38.75976562499
+        );
+    }
+
+    private static GatorConfig getDoryConfig() {
+        return new GatorConfig(
+            DRIVETRAIN_TRACKWIDTH_METERS_30X30,
+            DRIVETRAIN_TRACKWIDTH_METERS_30X30,
+            DRIVETRAIN_PIGEON_ID,
+            98.173828125,
+            149.23828125,
+            333.10546875,
+            102.8320312500
+        );
+    }
+}

--- a/src/main/java/frc/robot/config/GatorConfig.java
+++ b/src/main/java/frc/robot/config/GatorConfig.java
@@ -88,12 +88,13 @@ public class GatorConfig {
     // you can call this in robot container, drivetrainsubsystem, whatever.
     public static GatorConfig getConfig() {
         String serialNum;
-        // try to read the serial number from the RoboRIO
+        // try to read the serial number from the RoboRIO.
+        // if we can't, log an error pick a good default to return.
         try {
-            serialNum = new String(Files.readAllBytes(Paths.get("/sys/firmware/serial_number"))).trim();
-        } catch (IOException e) {
+            serialNum = edu.wpi.first.wpilibj.RobotController.getSerialNumber();
+        } catch (Exception e) {
             System.err.println("Failed to read RoboRIO serial number. Defaulting to practice bot config.");
-            return getCompBotConfig(); // Default to comp bot for now
+            return getCompBotConfig();
         }
 
         // based on the serial number, return the correct config.
@@ -107,6 +108,7 @@ public class GatorConfig {
             case "dory_serial": // Replace with actual serial
                 return getDoryConfig();
             default:
+                // if we don't have a config for this robot, log an error and return the comp bot config.
                 System.err.println("Unknown robot serial number: " + serialNum + ". Defaulting to comp bot config.");
                 return getCompBotConfig();
         }

--- a/src/main/java/frc/robot/config/GatorConfig.java
+++ b/src/main/java/frc/robot/config/GatorConfig.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import edu.wpi.first.wpilibj.RobotController;
+
 /**
  * Named GatorConfig because RobotConfig was already taken by wpilibj.
  * The intention here is  to replace Constants.java with this class.
@@ -19,8 +21,8 @@ public class GatorConfig {
     // go through a config object.
 
     //for a 25x25 dirvetrain
-    private static final double DRIVETRAIN_TRACKWIDTH_METERS_25X25 = 0.508;
-    private static final double DRIVETRAIN_WHEELBASE_METERS_25X25 = 0.508;
+    public static final double DRIVETRAIN_TRACKWIDTH_METERS_25X25 = 0.508;
+    public static final double DRIVETRAIN_WHEELBASE_METERS_25X25 = 0.508;
 
     //for a 30x30 drivetrain
     private static final double DRIVETRAIN_TRACKWIDTH_METERS_30X30 = 0.508 + 0.127;
@@ -30,13 +32,13 @@ public class GatorConfig {
     private static final int DRIVETRAIN_PIGEON_ID = 6;
 
     // these are member variables for the actual config.
-    private double driveTrainTrackWidthMeters;
-    private double driveTrainWheelBaseMeters;
-    private int driveTrainPigeonId;
-    private double driveTrainFrontLeftModuleSteerOffset;
-    private double driveTrainFrontRightModuleSteerOffset;
-    private double driveTrainBackLeftModuleSteerOffset;
-    private double driveTrainBackRightModuleSteerOffset;
+    public final double driveTrainTrackWidthMeters;
+    public final double driveTrainWheelBaseMeters;
+    public final int driveTrainPigeonId;
+    public final double driveTrainFrontLeftModuleSteerOffset;
+    public final double driveTrainFrontRightModuleSteerOffset;
+    public final double driveTrainBackLeftModuleSteerOffset;
+    public final double driveTrainBackRightModuleSteerOffset;
     
     // your average run of the mill constructor
     public GatorConfig(
@@ -56,61 +58,36 @@ public class GatorConfig {
         this.driveTrainBackRightModuleSteerOffset = driveTrainBackRightModuleSteerOffset;
     }
 
-    public double getDriveTrainTrackWidthMeters() {
-        return driveTrainTrackWidthMeters;
-    }
-
-    public double getDriveTrainWheelBaseMeters() {
-        return driveTrainWheelBaseMeters;
-    }
-
-    public int getDriveTrainPigeonId() {
-        return driveTrainPigeonId;
-    }
-
-    public double getDriveTrainFrontLeftModuleSteerOffset() {
-        return driveTrainFrontLeftModuleSteerOffset;
-    }
-
-    public double getDriveTrainFrontRightModuleSteerOffset() {
-        return driveTrainFrontRightModuleSteerOffset;
-    }
-
-    public double getDriveTrainBackLeftModuleSteerOffset() {
-        return driveTrainBackLeftModuleSteerOffset;
-    }
-
-    public double getDriveTrainBackRightModuleSteerOffset() {
-        return driveTrainBackRightModuleSteerOffset;
-    }
-
     // this is a static method that returns a new config based on the RoboRIO serial number.
     // you can call this in robot container, drivetrainsubsystem, whatever.
     public static GatorConfig getConfig() {
-        String serialNum;
-        // try to read the serial number from the RoboRIO.
-        // if we can't, log an error pick a good default to return.
-        try {
-            serialNum = edu.wpi.first.wpilibj.RobotController.getSerialNumber();
-        } catch (Exception e) {
-            System.err.println("Failed to read RoboRIO serial number. Defaulting to practice bot config.");
-            return getCompBotConfig();
-        }
+        // if we're running on a real robot, read the serial number and return the correct config.
+        if (edu.wpi.first.wpilibj.RobotBase.isReal()) {
+            String serialNum;
+            try {
+                serialNum = edu.wpi.first.wpilibj.RobotController.getSerialNumber();
+            } catch (Exception e) {
+                System.err.println("Failed to read RoboRIO serial number. Defaulting to comp bot config.");
+                return getCompBotConfig();
+            }
 
-        // based on the serial number, return the correct config.
-        switch (serialNum) {
-            case "031b1d4b": // Comp Bot
-                return getCompBotConfig();
-            case "nemo_serial": // Replace with actual serial
-                return getNemoConfig();
-            case "hulk_serial": // Replace with actual serial
-                return getHulkConfig();
-            case "dory_serial": // Replace with actual serial
-                return getDoryConfig();
-            default:
-                // if we don't have a config for this robot, log an error and return the comp bot config.
-                System.err.println("Unknown robot serial number: " + serialNum + ". Defaulting to comp bot config.");
-                return getCompBotConfig();
+            switch (serialNum) {
+                case "031b1d4b": // Comp Bot
+                    return getCompBotConfig();
+                case "nemo_serial": // Replace with actual serial
+                    return getNemoConfig();
+                case "hulk_serial": // Replace with actual serial
+                    return getHulkConfig();
+                case "dory_serial": // Replace with actual serial
+                    return getDoryConfig();
+                default:
+                    System.err.println("Unknown robot serial number: " + serialNum + ". Defaulting to comp bot config.");
+                    return getCompBotConfig();
+            }
+        } else {
+            // We're in simulation/test environment
+            System.out.println("Running in simulation mode. Using comp bot config.");
+            return getCompBotConfig();
         }
     }
 

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -12,6 +12,7 @@ import frc.com.swervedrivespecialties.swervelib.SdsModuleConfigurations;
 import frc.com.swervedrivespecialties.swervelib.SwerveModule;
 import frc.robot.Constants;
 import frc.robot.LimelightHelpers;
+import frc.robot.config.GatorConfig;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
@@ -32,11 +33,13 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class DrivetrainSubsystem extends SubsystemBase {
     private static final double MAX_VOLTAGE = 12.0;
+    // still a static, but built based on the rio serial number
+    private static final GatorConfig robotConfig = GatorConfig.getConfig();
     public static final double MAX_VELOCITY_METERS_PER_SECOND = 6380 / 60
             * SdsModuleConfigurations.MK4_L2.getDriveReduction() * SdsModuleConfigurations.MK4_L2.getWheelDiameter()
             * Math.PI;
     public static final double MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND = MAX_VELOCITY_METERS_PER_SECOND /
-            Math.hypot(Constants.DRIVETRAIN_TRACKWIDTH_METERS / 2.0, Constants.DRIVETRAIN_WHEELBASE_METERS / 2.0);
+            Math.hypot(robotConfig.getDriveTrainTrackWidthMeters() / 2.0, robotConfig.getDriveTrainWheelBaseMeters() / 2.0);
 
     private final SwerveModule frontLeftModule;
     private final SwerveModule frontRightModule;
@@ -75,17 +78,17 @@ public class DrivetrainSubsystem extends SubsystemBase {
         slowDrive = false;
         shuffleboardTab = Shuffleboard.getTab("Drivetrain");
 
-        pigeon = new Pigeon2(Constants.DRIVETRAIN_PIGEON_ID, Constants.CANIVORE_BUS_NAME);
+        pigeon = new Pigeon2(robotConfig.getDriveTrainPigeonId(), Constants.CANIVORE_BUS_NAME);
 
         kinematics = new SwerveDriveKinematics(
-                new Translation2d(Constants.DRIVETRAIN_TRACKWIDTH_METERS / 2.0,
-                        Constants.DRIVETRAIN_WHEELBASE_METERS / 2.0),
-                new Translation2d(Constants.DRIVETRAIN_TRACKWIDTH_METERS / 2.0,
-                        -Constants.DRIVETRAIN_WHEELBASE_METERS / 2.0),
-                new Translation2d(-Constants.DRIVETRAIN_TRACKWIDTH_METERS / 2.0,
-                        Constants.DRIVETRAIN_WHEELBASE_METERS / 2.0),
-                new Translation2d(-Constants.DRIVETRAIN_TRACKWIDTH_METERS / 2.0,
-                        -Constants.DRIVETRAIN_WHEELBASE_METERS / 2.0));
+                new Translation2d(robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
+                        robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
+                new Translation2d(robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
+                        -robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
+                new Translation2d(-robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
+                        robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
+                new Translation2d(-robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
+                        -robotConfig.getDriveTrainWheelBaseMeters() / 2.0));
 
         chassisSpeeds = new ChassisSpeeds(0.0, 0.0, 0.0);
 

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -39,7 +39,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
             * SdsModuleConfigurations.MK4_L2.getDriveReduction() * SdsModuleConfigurations.MK4_L2.getWheelDiameter()
             * Math.PI;
     public static final double MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND = MAX_VELOCITY_METERS_PER_SECOND /
-            Math.hypot(robotConfig.getDriveTrainTrackWidthMeters() / 2.0, robotConfig.getDriveTrainWheelBaseMeters() / 2.0);
+            Math.hypot(robotConfig.driveTrainTrackWidthMeters / 2.0, robotConfig.driveTrainWheelBaseMeters / 2.0);
 
     private final SwerveModule frontLeftModule;
     private final SwerveModule frontRightModule;
@@ -78,17 +78,17 @@ public class DrivetrainSubsystem extends SubsystemBase {
         slowDrive = false;
         shuffleboardTab = Shuffleboard.getTab("Drivetrain");
 
-        pigeon = new Pigeon2(robotConfig.getDriveTrainPigeonId(), Constants.CANIVORE_BUS_NAME);
+        pigeon = new Pigeon2(robotConfig.driveTrainPigeonId, Constants.CANIVORE_BUS_NAME);
 
         kinematics = new SwerveDriveKinematics(
-                new Translation2d(robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
-                        robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
-                new Translation2d(robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
-                        -robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
-                new Translation2d(-robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
-                        robotConfig.getDriveTrainWheelBaseMeters() / 2.0),
-                new Translation2d(-robotConfig.getDriveTrainTrackWidthMeters() / 2.0,
-                        -robotConfig.getDriveTrainWheelBaseMeters() / 2.0));
+                new Translation2d(robotConfig.driveTrainTrackWidthMeters / 2.0,
+                        robotConfig.driveTrainWheelBaseMeters / 2.0),
+                new Translation2d(robotConfig.driveTrainTrackWidthMeters / 2.0,
+                        -robotConfig.driveTrainWheelBaseMeters / 2.0),
+                new Translation2d(-robotConfig.driveTrainTrackWidthMeters / 2.0,
+                        robotConfig.driveTrainWheelBaseMeters / 2.0),
+                new Translation2d(-robotConfig.driveTrainTrackWidthMeters / 2.0,
+                        -robotConfig.driveTrainWheelBaseMeters / 2.0));
 
         chassisSpeeds = new ChassisSpeeds(0.0, 0.0, 0.0);
 


### PR DESCRIPTION
Things to note:
1. We get rid of some stuff in constants.java, especially commented out stuff
2. GatorConfig.java is long, but really, not worse than Constants.java.
3. DrivetrainSubsystem isn't really that much worse. You call `GatorConfig.getConfig`, it's static so you can use it to initialize other statics. Then just use values in the config instead of Constants.java.