### PR TITLE
Drive a direction

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,15 +29,15 @@ public class Constants {
     // public static final String CANIVORE_BUS_NAME = "";
 
     //nemo
-    // public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(336.094);
-    // public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(225.176);
-    // public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(243.369);
-    // public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(204.256);
-    // public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
-    // public static final String CANIVORE_BUS_NAME = "";
+    public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(336.094);
+    public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(225.176);
+    public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(243.369);
+    public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(204.256);
+    public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
+    public static final String CANIVORE_BUS_NAME = "";
     // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.172, 0.325, 0.197, new Rotation3d(Math.toRadians(10.0), Math.toRadians(-23.0), Math.toRadians(-46.0)));
-    // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.138, 0.346075, 0.2651125, new Rotation3d(Math.toRadians(2), Math.toRadians(0), Math.toRadians(0)));
-    // public static final double CENTER_TO_BUMPER_OFFSET = 0.3937;
+    public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.138, 0.346075, 0.2651125, new Rotation3d(Math.toRadians(2), Math.toRadians(0), Math.toRadians(0)));
+    public static final double CENTER_TO_BUMPER_OFFSET = 0.3937;
 
 
     // dory
@@ -57,14 +57,14 @@ public class Constants {
     // public static final double ELEVATOR_INVERT = 1.0; // 1.0 means the elevator is NOT inverted
 
     //comp bot
-    public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(268.0664);
-    public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(231.3281);
-    public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(229.57);
-    public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(52.1191);
-    public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
-    public static final String CANIVORE_BUS_NAME = "TRex";
-    public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.3394, 0.039, 0.196, new Rotation3d(Math.toRadians(1), Math.toRadians(-19.5), Math.toRadians(-3.0)));
-    public static final double CENTER_TO_BUMPER_OFFSET = 0.45164;
+    // public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(268.0664);
+    // public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(231.3281);
+    // public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(229.57);
+    // public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(52.1191);
+    // public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
+    // public static final String CANIVORE_BUS_NAME = "TRex";
+    // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.3394, 0.039, 0.196, new Rotation3d(Math.toRadians(1), Math.toRadians(-19.5), Math.toRadians(-3.0)));
+   // public static final double CENTER_TO_BUMPER_OFFSET = 0.45164;
     public static final Pose2d FRONT_CENTER_ALIGN_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET, 0, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag
     public static final Pose2d INTAKE_ALIGN_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET - 0.3, 0, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag
     public static final Pose2d SHOOTING_L4_LEFT_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET + 0.06, -CENTER_TO_POST +0.02 /*-0.161925*/, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,15 +29,15 @@ public class Constants {
     // public static final String CANIVORE_BUS_NAME = "";
 
     //nemo
-    public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(336.094);
-    public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(225.176);
-    public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(243.369);
-    public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(204.256);
-    public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
-    public static final String CANIVORE_BUS_NAME = "";
-    // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.172, 0.325, 0.197, new Rotation3d(Math.toRadians(10.0), Math.toRadians(-23.0), Math.toRadians(-46.0)));
-    public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.138, 0.346075, 0.2651125, new Rotation3d(Math.toRadians(2), Math.toRadians(0), Math.toRadians(0)));
-    public static final double CENTER_TO_BUMPER_OFFSET = 0.3937;
+    // public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(336.094);
+    // public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(225.176);
+    // public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(243.369);
+    // public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(204.256);
+    // public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
+    // public static final String CANIVORE_BUS_NAME = "";
+    // // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.172, 0.325, 0.197, new Rotation3d(Math.toRadians(10.0), Math.toRadians(-23.0), Math.toRadians(-46.0)));
+    // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.138, 0.346075, 0.2651125, new Rotation3d(Math.toRadians(2), Math.toRadians(0), Math.toRadians(0)));
+    // public static final double CENTER_TO_BUMPER_OFFSET = 0.3937;
 
 
     // dory
@@ -57,14 +57,14 @@ public class Constants {
     // public static final double ELEVATOR_INVERT = 1.0; // 1.0 means the elevator is NOT inverted
 
     //comp bot
-    // public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(268.0664);
-    // public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(231.3281);
-    // public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(229.57);
-    // public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(52.1191);
-    // public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
-    // public static final String CANIVORE_BUS_NAME = "TRex";
-    // public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.3394, 0.039, 0.196, new Rotation3d(Math.toRadians(1), Math.toRadians(-19.5), Math.toRadians(-3.0)));
-   // public static final double CENTER_TO_BUMPER_OFFSET = 0.45164;
+    public static final double FRONT_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(268.0664);
+    public static final double FRONT_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(231.3281);
+    public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(229.57);
+    public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(52.1191);
+    public static final MechanicalConfiguration MODULE_CONFIGURATION = SdsModuleConfigurations.MK4I_L2;
+    public static final String CANIVORE_BUS_NAME = "TRex";
+    public static final Pose3d LIMELIGHT_OFFSETS = new Pose3d(0.3394, 0.039, 0.196, new Rotation3d(Math.toRadians(1), Math.toRadians(-19.5), Math.toRadians(-3.0)));
+   public static final double CENTER_TO_BUMPER_OFFSET = 0.45164;
     public static final Pose2d FRONT_CENTER_ALIGN_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET, 0, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag
     public static final Pose2d INTAKE_ALIGN_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET - 0.3, 0, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag
     public static final Pose2d SHOOTING_L4_LEFT_OFFSET = new Pose2d(CENTER_TO_BUMPER_OFFSET + 0.06, -CENTER_TO_POST +0.02 /*-0.161925*/, new Rotation2d(0)); //offset from center of robot to where we want to line up with the april tag

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import frc.robot.subsystems.CoralShooterSubsystem;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.LimelightSubsystem;
 import frc.robot.commands.PointToTagCommand;
+import frc.robot.commands.DriveBackwardsCommand;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 
@@ -125,8 +126,8 @@ public class RobotContainer {
         new Trigger(controller::getBButtonPressed)
             .onTrue(new InstantCommand(m_coralShooterSub::increaseVoltageTune));
 
-        // new Trigger(controller::getYButton)
-        //     .onTrue(new PointToReefCommand(drivetrainSubsystem, controller));
+        new Trigger(controller::getYButton)
+            .onTrue(new DriveBackwardsCommand(drivetrainSubsystem, controller));
 
  /* CO-DRIVER BUTTON BOARD 1 BUTTONS */
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -126,8 +126,8 @@ public class RobotContainer {
         new Trigger(controller::getBButtonPressed)
             .onTrue(new InstantCommand(m_coralShooterSub::increaseVoltageTune));
 
-        new Trigger(controller::getYButton)
-            .onTrue(new DriveBackwardsCommand(drivetrainSubsystem, controller));
+        // new Trigger(controller::getYButton)
+        //     .onTrue(new DriveBackwardsCommand(drivetrainSubsystem, controller));
 
  /* CO-DRIVER BUTTON BOARD 1 BUTTONS */
 

--- a/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
+++ b/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
@@ -3,6 +3,7 @@ package frc.robot.commands;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.DrivetrainSubsystem;
@@ -28,7 +29,7 @@ public class DriveBackwardsCommand extends Command {
 
     @Override
     public void execute() {
-        drivetrain.driveADirection(180, 90);
+        drivetrain.driveADirection(180); //I am assuming that 180 is always pointing towards the driver. Need to double check with Phoenix
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
+++ b/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
@@ -29,7 +29,7 @@ public class DriveBackwardsCommand extends Command {
 
     @Override
     public void execute() {
-        drivetrain.driveADirection(180); //I am assuming that 180 is always pointing towards the driver. Need to double check with Phoenix
+        drivetrain.driveADirection(180);
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
+++ b/src/main/java/frc/robot/commands/DriveBackwardsCommand.java
@@ -1,0 +1,55 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+import java.util.function.DoubleSupplier;
+
+public class DriveBackwardsCommand extends Command {
+    private final DrivetrainSubsystem drivetrain;
+    private final XboxController controller;
+   
+
+    public DriveBackwardsCommand(DrivetrainSubsystem drivetrain, XboxController controller) {
+        this.drivetrain = drivetrain;
+        this.controller = controller;
+        addRequirements(drivetrain);
+    }
+
+    @Override
+    public void initialize() {
+        // System.out.println("TeleopDriveCommand initialized - stopping drivetrain");
+        drivetrain.drive(new ChassisSpeeds(0.0, 0.0, 0.0));
+    }
+
+    @Override
+    public void execute() {
+        drivetrain.driveADirection(180, 90);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        // System.out.println("TeleopDriveCommand ended");
+        drivetrain.drive(new ChassisSpeeds(0.0, 0.0, 0.0));
+    }
+
+    @Override
+    public boolean isFinished() {
+        if(drivetrain.getAtDesiredPose()){
+            return true;
+        }
+        boolean joystickMoved = Math.abs(controller.getLeftX()) > 0.2 ||
+        Math.abs(controller.getLeftY()) > 0.2 ||
+        Math.abs(controller.getRightX()) > 0.2 ||
+        Math.abs(controller.getRightY()) > 0.2;
+        if (joystickMoved) {
+            System.out.println("Joystick moved, ending command.");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -489,24 +489,39 @@ public class DrivetrainSubsystem extends SubsystemBase {
         robotRelativeDrive = !robotRelativeDrive;
     }
 
-    public void driveADirection(double direction, double angle){
-        Pose2d currentPose = odometry.getEstimatedPosition();
-        double rotationError = angle - currentPose.getRotation().getDegrees();
-        rotationError = MathUtil.inputModulus(rotationError, -180, 180); // sets the value between -180 and 180
+    // public void driveADirection(double direction, double angle){ //THIS WILL ONLY WORK IF DIRECTION IS FIELD RELATIVE
+       
+    //     Pose2d currentPose = odometry.getEstimatedPosition();
+    //     double fieldRelativeDirection = direction+currentPose.getRotation().getDegrees();
+    //     fieldRelativeDirection = direction;
+    //     double rotationError = angle - currentPose.getRotation().getDegrees();
+    //     rotationError = MathUtil.inputModulus(rotationError, -180, 180); // sets the value between -180 and 180
 
-        if (Math.abs(rotationError) < ROTATION_DEADBAND) {
-            rotationError = 0.0;
-             System.out.println("AT ROTATION DEADBAND");
-        }
+    //     if (Math.abs(rotationError) < ROTATION_DEADBAND) {
+    //         rotationError = 0.0;
+    //          System.out.println("AT ROTATION DEADBAND");
+    //     }
 
-        double xSpeed = Math.cos(Math.toRadians(direction))*0.5;
-        double ySpeed = Math.sin(Math.toRadians(direction))*0.5;
-        double rotationSpeed = Math.max(Math.abs(rotationError * ROTATION_kP), ROTATION_MIN_SPEED) * Math.signum(rotationError);
+    //     double xSpeed = Math.cos(Math.toRadians(fieldRelativeDirection))*0.5;
+    //     double ySpeed = Math.sin(Math.toRadians(fieldRelativeDirection))*0.5;
+    //     double rotationSpeed = Math.max(Math.abs(rotationError * ROTATION_kP), ROTATION_MIN_SPEED) * Math.signum(rotationError);
         
-        if(rotationSpeed >= 1.8){
-            rotationSpeed = 1.8;
-        }
+    //     if(rotationSpeed >= 1.8){
+    //         rotationSpeed = 1.8;
+    //     }
     
+    //     drive(ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, currentPose.getRotation()));
+    // }
+
+    public void driveADirection(double direction){ //direction should be robot relative
+        Pose2d currentPose = odometry.getEstimatedPosition();
+        double fieldRelativeDirection = direction+currentPose.getRotation().getDegrees();
+        fieldRelativeDirection = MathUtil.inputModulus(fieldRelativeDirection, -180, 180);
+
+        double xSpeed = Math.cos(Math.toRadians(fieldRelativeDirection))*0.9;
+        double ySpeed = Math.sin(Math.toRadians(fieldRelativeDirection))*0.9;
+        double rotationSpeed = 0;
+        
         drive(ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, currentPose.getRotation()));
     }
 }

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -488,4 +488,25 @@ public class DrivetrainSubsystem extends SubsystemBase {
     public void toggleRobotRelativeDrive(){
         robotRelativeDrive = !robotRelativeDrive;
     }
+
+    public void driveADirection(double direction, double angle){
+        Pose2d currentPose = odometry.getEstimatedPosition();
+        double rotationError = angle - currentPose.getRotation().getDegrees();
+        rotationError = MathUtil.inputModulus(rotationError, -180, 180); // sets the value between -180 and 180
+
+        if (Math.abs(rotationError) < ROTATION_DEADBAND) {
+            rotationError = 0.0;
+             System.out.println("AT ROTATION DEADBAND");
+        }
+
+        double xSpeed = Math.cos(Math.toRadians(direction))*0.5;
+        double ySpeed = Math.sin(Math.toRadians(direction))*0.5;
+        double rotationSpeed = Math.max(Math.abs(rotationError * ROTATION_kP), ROTATION_MIN_SPEED) * Math.signum(rotationError);
+        
+        if(rotationSpeed >= 1.8){
+            rotationSpeed = 1.8;
+        }
+    
+        drive(ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, currentPose.getRotation()));
+    }
 }

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -513,14 +513,18 @@ public class DrivetrainSubsystem extends SubsystemBase {
     //     drive(ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, currentPose.getRotation()));
     // }
 
-    public void driveADirection(double direction){ //direction should be robot relative
+    public void driveADirection(double direction){ 
+        //direction should be robot relative and in degrees. for clarity direction means angle at which we are driving, it does not refer to the robot heading
+        //for anyone that knows polar coordinates you can think of direction as theta and in this case our r would be infinite because we just keep driving
         Pose2d currentPose = odometry.getEstimatedPosition();
+        //the robot drives field relative so we need to find the field relative direction we want to drive in by adding the current heading to the desired robot relative drive direction
         double fieldRelativeDirection = direction+currentPose.getRotation().getDegrees();
         fieldRelativeDirection = MathUtil.inputModulus(fieldRelativeDirection, -180, 180);
 
+        //think unit circle and the math will make sense (basically scaling x and y speed to get us to drive in at a specific angle)
         double xSpeed = Math.cos(Math.toRadians(fieldRelativeDirection))*0.9;
         double ySpeed = Math.sin(Math.toRadians(fieldRelativeDirection))*0.9;
-        double rotationSpeed = 0;
+        double rotationSpeed = 0; //because we aren't altering heading
         
         drive(ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, currentPose.getRotation()));
     }

--- a/src/test/java/frc/robot/subsystems/PointToReefTest.java
+++ b/src/test/java/frc/robot/subsystems/PointToReefTest.java
@@ -117,7 +117,6 @@ public class PointToReefTest {
        System.out.println("red 4: " + PointToTagCommand.getTagCoords("red", 4));
        System.out.println("red 5: " + PointToTagCommand.getTagCoords("red", 5));
        System.out.println("red 6: " + PointToTagCommand.getTagCoords("red", 6));
-       
     }
 
 


### PR DESCRIPTION
Added a drive backwards command that uses a new driveADirection method in drivetrain subsystem that just takes a robot relative angle and drives that direction (as the name would imply). Tested on nemo and it works! There is also a commented out version that takes in a heading, this would work except you would need to feed it a field relative angle so slightly less intuitive and also not what we need at the moment, however we could uncomment it and use it at a later date.